### PR TITLE
Updated from Column to LazyColumn for performance, and due to Column …

### DIFF
--- a/app/src/main/java/com/puchunguita/cbzconverter/MainViewModel.kt
+++ b/app/src/main/java/com/puchunguita/cbzconverter/MainViewModel.kt
@@ -98,16 +98,16 @@ class MainViewModel(private val contextHelper: ContextHelper) : ViewModel() {
     }
 
     private fun updateCurrentTaskStatusMessageByAppending(message: String) {
-        _currentTaskStatus.update { currentMessage -> currentMessage.plus("\n$message") }
+        _currentTaskStatus.update { currentMessage -> message.plus("\n$currentMessage") }
     }
 
     private fun updateCurrentSubTaskStatusMessage(message: String) {
         _currentSubTaskStatus.update { message }
     }
 
-    private suspend fun updateCurrentSubTaskStatusStatusMessage(message: String) {
+    private suspend fun updateCurrentSubTaskStatusMessageSuspendByAppending(message: String) {
         withContext(Dispatchers.Main) {
-            _currentSubTaskStatus.update { currentMessage -> currentMessage.plus("\n$message") }
+            _currentSubTaskStatus.update { currentMessage -> message.plus("\n$currentMessage") }
             logger.info(message)
         }
     }
@@ -209,12 +209,13 @@ class MainViewModel(private val contextHelper: ContextHelper) : ViewModel() {
                 val outputFolder = getOutputFolder()
 
                 updateCurrentTaskStatusMessageSuspend(message = "Conversion from CBZ to PDF started")
+                updateCurrentSubTaskStatusMessage(message = "")
                 val pdfFiles = convertCbzToPdf(
                     fileUri = fileUris,
                     contextHelper = contextHelper,
                     subStepStatusAction = { message: String ->
                         CoroutineScope(Dispatchers.Main).launch {
-                            updateCurrentSubTaskStatusStatusMessage(message)
+                            updateCurrentSubTaskStatusMessageSuspendByAppending(message)
                         }
                     },
                     maxNumberOfPages = _maxNumberOfPages.value,

--- a/app/src/main/java/com/puchunguita/cbzconverter/ui/components/CbzConverterPage.kt
+++ b/app/src/main/java/com/puchunguita/cbzconverter/ui/components/CbzConverterPage.kt
@@ -11,6 +11,8 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
@@ -74,29 +76,25 @@ private fun TasksStatusSegment(currentTaskStatus: String, currentSubTaskStatus: 
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(text = "Current Task Status (Scrollable):", fontWeight = FontWeight.SemiBold)
-        Column(
+        LazyColumn(
             Modifier.height(100.dp),
-            verticalArrangement = Arrangement.Center,
+            verticalArrangement = Arrangement.Center
         ) {
-            val scroll = rememberScrollState(0)
-            LaunchedEffect(currentTaskStatus) {
-                scroll.animateScrollTo(scroll.maxValue)
+            items(currentTaskStatus.lines()) { line ->
+                Text(text = line)
             }
-            Text(text = currentTaskStatus, modifier = Modifier.verticalScroll(scroll))
         }
 
         Spacer(modifier = Modifier.height(16.dp))
 
         Text(text = "Current Sub-Task Status (Scrollable):", fontWeight = FontWeight.SemiBold)
-        Column(
+        LazyColumn(
             Modifier.height(130.dp),
-            verticalArrangement = Arrangement.Center,
+            verticalArrangement = Arrangement.Center
         ) {
-            val scroll = rememberScrollState(0)
-            LaunchedEffect(currentSubTaskStatus) {
-                scroll.animateScrollTo(scroll.maxValue)
+            items(currentSubTaskStatus.lines()) { line ->
+                Text(text = line)
             }
-            Text(text = currentSubTaskStatus, modifier = Modifier.verticalScroll(scroll))
         }
     }
 }


### PR DESCRIPTION
…crashing if there was too many logs.

Flipped the appending for CurrentTaskStatusMessage and updateCurrentSubTaskStatusMessage so new entries are on top, this eliminated the need to force scroll back when using a Column to view most up to date detail. Removed unneeded subStepStatusAction() within addEntriesToZip(), as it was adding too much noise. Added flush() within addEntriesToZip() and extractImageAndAddToPDFDocument(). Re-worked extractImageAndAddToPDFDocument() to use a temp image file instead of directly using an InputStream(), and deleting temp image file once done.