### PR TITLE
Fix for merged files over 512 mb limit

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,7 +53,7 @@ android {
 dependencies {
 
     implementation ("com.anggrayudi:storage:2.0.0")
-    implementation("com.itextpdf:itext7-core:7.2.6")
+    implementation("com.itextpdf:itext-core:9.0.0")
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -12,7 +12,7 @@ android {
         minSdk = 24
         targetSdk = 35
         versionCode = 1
-        versionName = "1.0"
+        versionName = "1.0.4"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {

--- a/app/src/main/java/com/puchunguita/cbzconverter/MainViewModel.kt
+++ b/app/src/main/java/com/puchunguita/cbzconverter/MainViewModel.kt
@@ -26,7 +26,7 @@ class MainViewModel(private val contextHelper: ContextHelper) : ViewModel() {
         private const val NOTHING_PROCESSING = "Nothing Processing"
         private const val NO_FILE_SELECTED = "No file selected"
         const val EMPTY_STRING = ""
-        private const val DEFAULT_MAX_NUMBER_OF_PAGES = 500
+        private const val DEFAULT_MAX_NUMBER_OF_PAGES = 10000
     }
 
     private val logger = Logger.getLogger(MainViewModel::class.java.name)


### PR DESCRIPTION
Added new logic for when merging files occurs. If total number of pages are 300 or more, we will split them into multiple pdfs of 300 pages. Then use each of those 300 page pdf to directly copy them into a single pdf, this will limit memory usage to the size of a 300 page pdf at most. When merging is less than 300, previous logic of directly merging in memory will be used.

Updated itextpdf library from version 7 to version 9.
Updated DEFAULT_MAX_NUMBER_OF_PAGES to 10,000.
Cache directory will now be cleared, when starting the process of converting a CBZ to PDF.
Increased padding size of files when merging them into one giant CBZ, to support larger single files being merged.
